### PR TITLE
FastText update v0.9.2

### DIFF
--- a/explainer.py
+++ b/explainer.py
@@ -377,6 +377,6 @@ if __name__ == "__main__":
     # Evaluation text
     samples = [
         "It's not horrible, just horribly mediocre."
-        # "The cast is uniformly excellent ... but the film itself is merely mildly charming.",
+        "The cast is uniformly excellent ... but the film itself is merely mildly charming.",
     ]
     main(samples)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
 pytreebank==0.2.6
 tqdm==4.33.0
-cython==0.29.3
 pandas==0.25.0
 nltk==3.4.5
 textblob==0.15.3
 torch==1.1.0
 pytorch-ignite==0.2.0
 pytorch-transformers==1.0.0
-fasttext==0.9.1
+fasttext==0.9.2
 lime==0.1.1.36
 spacy==2.1.8
-# flair==0.4.2    # If not using flair, include this line
+# flair==0.4.2    # If using flair, uncomment this line
 # allennlp==0.8.4  # If using flair + elmo embeddings

--- a/training/train_fasttext.py
+++ b/training/train_fasttext.py
@@ -1,70 +1,51 @@
 """
 Python API for FastText text classification model training.
 
-All default arguments in this file are obtained using hyperparameter autotuning
-in fastText: https://fasttext.cc/docs/en/autotune.html
-
-Run the following command for the CLI utility to obtain optimum hyperparameters:
-
-./fasttext supervised -input sst_train.txt -output model \
--autotune-validation sst_dev.txt -autotune-modelsize 10M -verbose 3
+We train a sentiment classifier using automatic hyperparameter optimization:
+https://fasttext.cc/docs/en/autotune.html
 """
-
 import argparse
 import os
 import fasttext
 
 
-def make_dirs(dirpath: str) -> None:
-    """Make directories for output if necessary"""
-    if not os.path.exists(dirpath):
-        os.makedirs(dirpath)
-
-
 def trainer(filepath: str,
             train_file: str,
+            valid_file: str,
             model_path: str,
             hyper_params: dict) -> None:
-    """Train sentiment model using FastText:
-    https://fasttext.cc/docs/en/supervised-tutorial.html
+    """
+    Train sentiment model using FastText automatic hyperparameter optimization:
+    https://fasttext.cc/docs/en/autotune.html
     """
     train = os.path.join(filepath, train_file)
-    model = fasttext.train_supervised(input=train, **hyper_params)
-    print("FastText model trained with hyperparameters: \n {}".format(hyper_params))
-    # Save models to model directory for fasttext
-    make_dirs(model_path)
-    model.save_model(os.path.join(model_path, "sst5_hyperopt.bin"))
-    # Quantize model to reduce space usage
-    model.quantize(input=train, qnorm=True, retrain=True, cutoff=110539)
-    model.save_model(os.path.join(model_path, "sst5_hyperopt.ftz"))
+    valid = os.path.join(filepath, valid_file)
+    model = fasttext.train_supervised(
+        input=train,
+        autotuneValidationFile=valid,
+        **hyper_params,
+    )
+    os.makedirs(model_path, exist_ok=True)
+    model.save_model(f"{model_path}.ftz")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--filepath', type=str, help="Dataset path", default="../data/sst")
     parser.add_argument('--train', type=str, help="Training set filename", default="sst_train.txt")
-    parser.add_argument('--model', type=str, help="Trained model path", default="../models/fasttext")
-    parser.add_argument('--epochs', type=int, help="Number of epochs", default=100)
-    parser.add_argument('--lr', type=float, help="Learning rate", default=0.35)
-    parser.add_argument('--ws', type=int, help="Size of the context window", default=5)
-    parser.add_argument('--wordNgrams', type=int, help="Max length of word ngram", default=3)
-    parser.add_argument('--dim', type=int, help="Size of the word vectors", default=155)
-    parser.add_argument('--minn', type=int, help="Min length of char ngram", default=2)
-    parser.add_argument('--maxn', type=int, help="Max length of char ngram", default=5)
-    parser.add_argument('--bucket', type=int, help="Number of buckets", default=2014846)
+    parser.add_argument('--valid', type=str, help="Validation set filename", default="sst_dev.txt")
+    parser.add_argument('--model', type=str, help="Trained model path", default="../models/fasttext/model")
+    parser.add_argument("--duration", type=int, default=1800, help="Autotuning duration in seconds")
+    parser.add_argument("--modelsize", type=str, default="10M", help="Max allowed size for autotuned model file (`5M` means 5 MB)")
+    parser.add_argument("--disable_verbose", action="store_true", help="Disable verbosity in autotuning output")
 
     args = parser.parse_args()
 
-    # Use fastText command line utility to run hyperparameter optimization for best default args!
+    # Run automatic hyperparameter tuning during training
     hyper_params = {
-        "lr": args.lr,
-        "epoch": args.epochs,
-        "wordNgrams": args.wordNgrams,
-        "dim": args.dim,
-        "ws": args.ws,
-        "minn": args.minn,
-        "maxn": args.maxn,
-        "bucket": args.bucket,
+        "autotuneDuration": args.duration,
+        "autotuneModelSize": args.modelsize,
+        "verbose": 2 if args.disable_verbose else 3,  # '3' means verbose
     }
 
-    trainer(args.filepath, args.train, args.model, hyper_params)
+    trainer(args.filepath, args.train, args.valid, args.model, hyper_params)


### PR DESCRIPTION
* Updated code and README for hyperparameter autotuning using FastText 0.9.2
    * As of v0.9.2, the FastText Python interface and its CLI are more or less equivalent, so it makes sense to switch the training and tuning process over to a Python script instead of having to build the command-line utility manually. 
* Made LIME explainer more consistent with the examples discussed in the blog post